### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/android/app/src/main/java/io/metamask/nativeModules/RNTar/RNTar.java
+++ b/android/app/src/main/java/io/metamask/nativeModules/RNTar/RNTar.java
@@ -87,6 +87,12 @@ public class RNTar extends ReactContextBaseJavaModule {
         // Loop through the entries in the .tgz file
         while ((entry = (TarArchiveEntry) tarInputStream.getNextEntry()) != null) {
           File outputFile = new File(outputPath, entry.getName());
+          Path outputPathNormalized = Paths.get(outputFile.getCanonicalPath()).normalize();
+          Path outputDirNormalized = Paths.get(new File(outputPath).getCanonicalPath()).normalize();
+
+          if (!outputPathNormalized.startsWith(outputDirNormalized)) {
+            throw new IOException("Bad tar entry: " + entry.getName());
+          }
 
           // If it is a directory, create the output directory
           if (entry.isDirectory()) {


### PR DESCRIPTION
Potential fix for [https://github.com/pwnlaboratory/metamask-mobile/security/code-scanning/1](https://github.com/pwnlaboratory/metamask-mobile/security/code-scanning/1)

To fix the problem, we need to ensure that the output paths constructed from tar archive entries are validated to prevent writing files to unexpected locations. This can be done by verifying that the normalized full path of the output file starts with a prefix that matches the destination directory. We will use `java.nio.file.Path.normalize()` and `java.nio.file.Path.startsWith()` for this purpose.

1. Normalize the `outputFile` path.
2. Check if the normalized path starts with the normalized `outputPath`.
3. If the check fails, throw an exception to prevent writing the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
